### PR TITLE
#15 tooltip popover element target

### DIFF
--- a/components/app-bar/kor-app-bar.ts
+++ b/components/app-bar/kor-app-bar.ts
@@ -10,7 +10,7 @@ import { sharedStyles } from '../../shared-styles';
  * @slot functions - Displayed on the right side (if mobile is unset). Used for hosting components such as Icon and Avatar.
  * @slot left - Displayed on the left side (if mobile is set to true). Used for hosting components such as Icon.
  * @slot right - Displayed on the right side (if mobile is set to true). Used for hosting components such as Icon.
- * 
+ *
  * @fires logo-clicked - Fired when clicking on the logo.
  */
 

--- a/components/app-bar/package.json
+++ b/components/app-bar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kor-ui/app-bar",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Kor app-bar component.",
   "author": "Eduardo Ferreira",
   "license": "MIT",

--- a/components/popover/kor-popover.ts
+++ b/components/popover/kor-popover.ts
@@ -119,14 +119,20 @@ export class korPopover extends LitElement {
   }
 
   targetObserver() {
-    let tar = document.querySelector(this.target);
+    const tar =
+      typeof this.target === 'string'
+        ? document.querySelector(this.target)
+        : this.target;
     if (tar) {
       tar.addEventListener('click', () => this.handlePosition(tar));
     }
   }
 
   visibleObserver() {
-    let tar = document.querySelector(this.target);
+    const tar =
+      typeof this.target === 'string'
+        ? document.querySelector(this.target)
+        : this.target;
     if (tar) {
       this.handlePosition(tar);
     }

--- a/components/popover/package.json
+++ b/components/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kor-ui/popover",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Kor popover component.",
   "author": "Eduardo Ferreira",
   "license": "MIT",

--- a/components/table/kor-table-row.ts
+++ b/components/table/kor-table-row.ts
@@ -26,15 +26,15 @@ export class korTableRow extends LitElement {
         }
         /* active */
         :host([active]) {
-          background: rgba(var(--neutral-1), 0.1);
+          background-color: rgba(var(--neutral-1), 0.1);
         }
         /* hover inputs */
         @media (hover: hover) {
           :host(:hover:not([active]):not([slot='header'])) {
-            background: rgba(var(--neutral-1), 0.05);
+            background-color: rgba(var(--neutral-1), 0.05);
           }
           :host(:hover:not([active])):host-context(kor-table[readonly]) {
-            background: transparent;
+            background-color: transparent;
           }
         }
       `,
@@ -69,7 +69,7 @@ export class korTableRow extends LitElement {
   }
 
   handleColumns() {
-    let table: any = this.closest('kor-table');
+    const table: any = this.closest('kor-table');
     // define columns on load
     this.style.gridTemplateColumns = table.columns;
     // listen to column changes

--- a/components/table/package.json
+++ b/components/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kor-ui/table",
-  "version": "1.0.9",
+  "version": "1.1.4",
   "description": "Kor table component.",
   "author": "Eduardo Ferreira",
   "license": "MIT",

--- a/components/tooltip/kor-tooltip.ts
+++ b/components/tooltip/kor-tooltip.ts
@@ -89,7 +89,10 @@ export class korTooltip extends LitElement {
 
   targetObserver() {
     let timeout;
-    let tar = document.querySelector(this.target);
+    const tar =
+      typeof this.target === 'string'
+        ? document.querySelector(this.target)
+        : this.target;
     if (tar) {
       // show on mouse over
       tar.addEventListener('mouseover', () => {

--- a/components/tooltip/package.json
+++ b/components/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kor-ui/tooltip",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "Kor tooltip component.",
   "author": "Eduardo Ferreira",
   "license": "MIT",

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     ".",
     "components/*"
   ],
-  "version": "1.1.3"
+  "version": "1.1.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kor-ui/kor",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kor-ui/kor",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Web components library containing lightweight, ready-to-use and framework-agnostic User Interface elements.",
   "scripts": {
     "start": "webpack-dev-server --config webpack.dev.config.js",


### PR DESCRIPTION
Resolves #15 

- Tooltips and popovers now support 2 ways of target assignment:

**Previous method, still works:**
```html
<kor-icon id="mySelector"></kor-icon>
<kor-tooltip target="#mySelector"></kor-tooltip>
```

**New method, binding to an HTMLElement**
```html
<!-- new method -->
<kor-icon id="mySelector"></kor-icon>
<kor-tooltip [target]="myElement"></kor-tooltip>
```
```js
// this is the host web component
const webComponent = document.querySelector('#mySelector');
const myElement = webComponent.shadowRoot.querySelector('my-target');
```